### PR TITLE
Add preview modal workflow before saving recorded clips

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,58 +1,53 @@
 let mediaStream = null;
 let mediaRecorder = null;
 let recordedBlobs = [];
+let recordingTabId = null;
 let captureInfo = { title: "youtube_clip", timestamp: "00:00" }; // Store title/time
 
 const VIDEO_MIME_TYPE = 'video/webm;codecs=vp9'; // VP9 is generally good for web
-// const VIDEO_MIME_TYPE = 'video/mp4;codecs=h264'; // Alternative, might have less browser support for recording
+const pendingClips = new Map();
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    // Use an async function here to allow 'await' and properly handle promises/sendResponse
     (async () => {
         if (message.action === "startRecording") {
             if (mediaRecorder && mediaRecorder.state !== "inactive") {
                 console.warn("Background: Recording already in progress.");
                 sendResponse({ success: false, message: "Already recording." });
-                return; // Indicate message handled (implicitly)
+                return;
             }
 
             console.log("Background: Received startRecording", message.payload);
-            captureInfo = message.payload || captureInfo; // Store title/time
+            captureInfo = message.payload || captureInfo;
 
             try {
-                // Important: Get the tab where the message came from
                 const targetTabId = sender.tab?.id;
                 if (!targetTabId) {
-                   throw new Error("Could not get sender tab ID.");
+                    throw new Error("Could not get sender tab ID.");
                 }
+                recordingTabId = targetTabId;
 
-                // Start tab capture
                 mediaStream = await chrome.tabCapture.capture({
-                    audio: false, // No audio as requested
+                    audio: false,
                     video: true,
                     videoConstraints: {
                         mandatory: {
-                             // Request desired quality, browser will do its best
                             minWidth: 1280,
                             minHeight: 720,
                             maxWidth: 1920,
                             maxHeight: 1080,
-                            maxFrameRate: 30, // Capture at 30fps
+                            maxFrameRate: 30,
                         },
                     },
                 });
                 console.log("Background: Tab capture started.");
 
-                // Check if stream is valid
-                 if (!mediaStream || mediaStream.getVideoTracks().length === 0) {
-                     throw new Error("Failed to get video stream from tabCapture.");
-                 }
+                if (!mediaStream || mediaStream.getVideoTracks().length === 0) {
+                    throw new Error("Failed to get video stream from tabCapture.");
+                }
 
-                // Clear previous blobs
                 recordedBlobs = [];
 
-                // Create MediaRecorder
-                 mediaRecorder = new MediaRecorder(mediaStream, { mimeType: VIDEO_MIME_TYPE });
+                mediaRecorder = new MediaRecorder(mediaStream, { mimeType: VIDEO_MIME_TYPE });
 
                 mediaRecorder.ondataavailable = (event) => {
                     if (event.data && event.data.size > 0) {
@@ -61,115 +56,134 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     }
                 };
 
-                mediaRecorder.onstop = handleRecordingStop; // Assign the stop handler
+                mediaRecorder.onstop = () => handleRecordingStop(recordingTabId);
 
                 mediaRecorder.onerror = (event) => {
                     console.error("Background: MediaRecorder error:", event.error);
-                    // Clean up resources on error too
                     stopCaptureResources();
                 };
 
-                // Start recording
-                mediaRecorder.start(100); // Collect data in chunks (e.g., every 100ms)
+                mediaRecorder.start(100);
                 console.log("Background: MediaRecorder started.");
-                sendResponse({ success: true }); // Signal success back to content script
-
+                sendResponse({ success: true });
             } catch (error) {
                 console.error("Background: Error starting tab capture or MediaRecorder:", error);
-                stopCaptureResources(); // Clean up if error occurs during setup
-                 sendResponse({ success: false, message: error.message });
+                stopCaptureResources();
+                sendResponse({ success: false, message: error.message });
             }
-
         } else if (message.action === "stopRecording") {
-             console.log("Background: Received stopRecording message.");
-             if (mediaRecorder && mediaRecorder.state === "recording") {
-                 mediaRecorder.stop(); // This will trigger the 'onstop' event handler
-                 // stopCaptureResources() is called within handleRecordingStop after blobs are processed
-                 sendResponse({ success: true });
-             } else {
-                 console.warn("Background: Stop requested but recorder not active/found.");
-                 // Still try to clean up just in case stream exists without recorder
-                 stopCaptureResources();
-                 sendResponse({ success: false, message: "Recorder not active." });
-             }
+            console.log("Background: Received stopRecording message.");
+            if (mediaRecorder && mediaRecorder.state === "recording") {
+                mediaRecorder.stop();
+                sendResponse({ success: true });
+            } else {
+                console.warn("Background: Stop requested but recorder not active/found.");
+                stopCaptureResources();
+                sendResponse({ success: false, message: "Recorder not active." });
+            }
+        } else if (message.action === "saveClip") {
+            await saveClip(message.payload);
+            sendResponse({ success: true });
+        } else if (message.action === "discardClip") {
+            discardClip(message.payload?.clipId);
+            sendResponse({ success: true });
         }
-    })(); // Immediately invoke the async function
+    })();
 
-    // Return true to indicate you wish to send a response asynchronously
     return true;
 });
 
-function handleRecordingStop() {
+async function handleRecordingStop(targetTabId) {
     console.log("Background: MediaRecorder stopped.");
-    if (recordedBlobs && recordedBlobs.length > 0) {
-        const blob = new Blob(recordedBlobs, { type: VIDEO_MIME_TYPE });
 
-        // Sanitize filename
-        const safeTitle = captureInfo.title.replace(/[<>:"/\\|?*]+/g, '_').substring(0, 100); // Limit length too
-        const timestamp = captureInfo.timestamp || "00:00";
-        const filename = `${safeTitle}_clip_${timestamp}.webm`; // Use .webm extension
-
-        const url = URL.createObjectURL(blob);
-
-        console.log(`Background: Triggering download for ${filename}`);
-        chrome.downloads.download({
-            url: url,
-            filename: filename,
-            // saveAs: true // Uncomment to prompt user for save location each time
-        }).then(downloadId => {
-             console.log(`Background: Download started with ID: ${downloadId}`);
-            // Note: Can't easily revokeObjectURL here directly as download is async.
-            // Browser usually handles cleanup, but for long-running extensions, management might be needed.
-            // setTimeout(() => URL.revokeObjectURL(url), 60000); // Revoke after 1 min as fallback
-        }).catch(error => {
-            console.error("Background: Download failed:", error);
-            URL.revokeObjectURL(url); // Clean up if download initiation failed
-        });
-
-        // Clear blobs after processing
-         recordedBlobs = [];
-    } else {
-        console.warn("Background: Recording stopped but no data blobs found.");
+    if (!recordedBlobs || recordedBlobs.length === 0) {
+        console.warn("Background: No recorded data available.");
+        stopCaptureResources();
+        return;
     }
 
-    // Clean up stream/recorder resources AFTER processing blobs
-    stopCaptureResources();
+    const blob = new Blob(recordedBlobs, { type: VIDEO_MIME_TYPE });
+    const safeTitle = captureInfo.title.replace(/[<>:"/\\|?*]+/g, '_').substring(0, 100);
+    const timestamp = captureInfo.timestamp || "00:00";
+    const filename = `${safeTitle}_clip_${timestamp}.webm`;
+    const url = URL.createObjectURL(blob);
+    const clipId = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    pendingClips.set(clipId, { url, filename });
+
+    try {
+        if (typeof targetTabId === "number") {
+            await chrome.tabs.sendMessage(targetTabId, {
+                action: "clipReadyForPreview",
+                payload: {
+                    clipId,
+                    url,
+                    filename,
+                    title: captureInfo.title,
+                    timestamp,
+                },
+            });
+            console.log(`Background: Clip preview sent for ${filename}`);
+        }
+    } catch (error) {
+        console.error("Background: Failed to show preview, revoking clip.", error);
+        discardClip(clipId);
+    } finally {
+        stopCaptureResources();
+        recordingTabId = null;
+    }
+}
+
+async function saveClip(payload = {}) {
+    const { clipId, saveAs = false } = payload;
+    const clip = pendingClips.get(clipId);
+    if (!clip) {
+        console.warn("Background: saveClip requested for missing clip", clipId);
+        return;
+    }
+
+    try {
+        const downloadId = await chrome.downloads.download({
+            url: clip.url,
+            filename: clip.filename,
+            saveAs,
+        });
+        console.log(`Background: Download started with ID: ${downloadId}`);
+    } catch (error) {
+        console.error("Background: Failed to download clip", error);
+        throw error;
+    } finally {
+        setTimeout(() => discardClip(clipId), 30000);
+    }
+}
+
+function discardClip(clipId) {
+    if (!clipId) return;
+    const clip = pendingClips.get(clipId);
+    if (!clip) return;
+
+    URL.revokeObjectURL(clip.url);
+    pendingClips.delete(clipId);
+    console.log(`Background: Revoked clip URL for ${clipId}`);
 }
 
 function stopCaptureResources() {
-    if (mediaRecorder && mediaRecorder.state !== "inactive") {
-        // If somehow stop wasn't called cleanly, try again.
-        try { mediaRecorder.stop(); } catch (e) { console.warn("Error trying to stop recorder during cleanup:", e); }
+    if (mediaRecorder) {
+        mediaRecorder.onstop = null;
+        mediaRecorder.ondataavailable = null;
+        mediaRecorder.onerror = null;
+        mediaRecorder = null;
     }
-     if (mediaStream) {
-        mediaStream.getTracks().forEach(track => track.stop());
-        console.log("Background: MediaStream tracks stopped.");
+
+    if (mediaStream) {
+        mediaStream.getTracks().forEach((track) => {
+            if (track.readyState === "live") {
+                track.stop();
+                console.log(`Background: Stopped track: ${track.kind}`);
+            }
+        });
+        mediaStream = null;
     }
-    mediaRecorder = null;
-    mediaStream = null;
-    console.log("Background: Capture resources released.");
+
+    recordedBlobs = [];
 }
-
-// Add listeners for tab updates/removal to stop recording if the target tab changes/closes
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    // Check if the tab being updated is the one we are capturing
-    // And if the URL significantly changed (navigated away) or it's loading
-    if (mediaRecorder && mediaRecorder.state === "recording") {
-         const capturingTabId = mediaRecorder?.stream?.getVideoTracks()[0]?.getSettings()?.displaySurface?.tabId;
-         // Note: reliably getting tab ID from stream isn't straightforward, might need to store it separately when starting
-         // Let's rely on stopping via content script's interval checker for now, or handle tab removal.
-    }
-});
-
-chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
-    // Check if the closed tab is the one being recorded
-    // Requires storing targetTabId when starting capture
-    // if (tabId === storedTargetTabId && mediaRecorder && mediaRecorder.state === "recording") {
-    //    console.log(`Background: Target tab ${tabId} closed, stopping recording.`);
-    //    mediaRecorder.stop(); // Trigger stop and cleanup
-    // }
-    // Simplified: For now, assume content script handles navigation away,
-    // and if the whole browser closes, things stop anyway.
-});
-
-console.log("Background Service Worker started.");

--- a/content.js
+++ b/content.js
@@ -2,53 +2,44 @@ console.log("YouTube Clip Recorder: Content script loaded.");
 
 let recordButton = null;
 let isRecording = false;
-let stopTimeoutId = null; // Timer to auto-stop recording
-const MAX_RECORD_DURATION_MS = 10000; // 10 seconds
+let stopTimeoutId = null;
+let activePreviewClipId = null;
+let previewModalEl = null;
+const MAX_RECORD_DURATION_MS = 10000;
 
 function createRecordButton() {
     if (document.getElementById('yt-clip-recorder-button')) {
-        // Button already exists, potentially from a previous SPA navigation
         return document.getElementById('yt-clip-recorder-button');
     }
 
     const button = document.createElement('button');
     button.id = 'yt-clip-recorder-button';
-    button.textContent = 'REC Clip'; // Keep it short
-    button.classList.add('ytp-button'); // Try to mimic YouTube button style
-    button.style.marginLeft = '8px'; // Add some space
-    button.style.fontSize = '0.9em'; // Adjust size if needed
-    button.style.padding = '5px 8px'; // Adjust padding
+    button.textContent = 'REC Clip';
+    button.classList.add('ytp-button');
+    button.style.marginLeft = '8px';
+    button.style.fontSize = '0.9em';
+    button.style.padding = '5px 8px';
 
     button.onclick = handleRecordButtonClick;
 
-    // Try to inject the button into YouTube's control bar
-    // This selector might change with YouTube updates!
     const controlsRight = document.querySelector('.ytp-right-controls');
     if (controlsRight) {
-        // Insert it before the settings button for visibility
         const settingsButton = controlsRight.querySelector('.ytp-settings-button');
         if (settingsButton) {
             controlsRight.insertBefore(button, settingsButton);
         } else {
-             // Fallback: append to the end of right controls
-             controlsRight.appendChild(button);
+            controlsRight.appendChild(button);
         }
         console.log("YouTube Clip Recorder: Button injected.");
         return button;
-    } else {
-        console.warn("YouTube Clip Recorder: Could not find YouTube controls container.");
-        // Fallback: Append to body (less ideal)
-        // button.style.position = 'fixed';
-        // button.style.bottom = '20px';
-        // button.style.right = '20px';
-        // button.style.zIndex = '9999';
-        // document.body.appendChild(button);
-        return null; // Indicate failure to inject properly
     }
+
+    console.warn("YouTube Clip Recorder: Could not find YouTube controls container.");
+    return null;
 }
 
 async function handleRecordButtonClick() {
-    if (!recordButton) return; // Safety check
+    if (!recordButton) return;
 
     const videoElement = document.querySelector('video.html5-main-video');
     if (!videoElement) {
@@ -58,117 +49,184 @@ async function handleRecordButtonClick() {
     }
 
     if (!isRecording) {
-        // --- Start Recording ---
         isRecording = true;
-        recordButton.textContent = 'STOP ■'; // Indicate recording
-        recordButton.style.color = 'red'; // Visual feedback
+        recordButton.textContent = 'STOP ■';
+        recordButton.style.color = 'red';
 
-        const videoTitle = document.title.replace(/ - YouTube$/, ''); // Get clean title
+        const videoTitle = document.title.replace(/ - YouTube$/, '');
         const currentTimeSeconds = Math.floor(videoElement.currentTime);
-        const timestamp = new Date(currentTimeSeconds * 1000).toISOString().substr(14, 5); // Format as MM:SS
+        const timestamp = new Date(currentTimeSeconds * 1000).toISOString().substr(14, 5);
 
         try {
-            // Send message to background script to start
             await chrome.runtime.sendMessage({
                 action: "startRecording",
-                payload: { title: videoTitle, timestamp: timestamp }
+                payload: { title: videoTitle, timestamp },
             });
             console.log("YouTube Clip Recorder: Start recording message sent.");
 
-            // Set timeout for automatic stop
             stopTimeoutId = setTimeout(() => {
                 console.log("YouTube Clip Recorder: Max duration reached, stopping automatically.");
-                handleRecordButtonClick(); // Call this function again to trigger the stop logic
+                handleRecordButtonClick();
             }, MAX_RECORD_DURATION_MS);
-
         } catch (error) {
             console.error("YouTube Clip Recorder: Error starting recording.", error);
             alert(`Error starting recording: ${error.message}`);
-            // Reset UI if start failed
             isRecording = false;
             recordButton.textContent = 'REC Clip';
-            recordButton.style.color = ''; // Reset color
+            recordButton.style.color = '';
             clearTimeout(stopTimeoutId);
             stopTimeoutId = null;
         }
-
     } else {
-        // --- Stop Recording ---
         isRecording = false;
-        recordButton.textContent = 'REC Clip'; // Reset text immediately
-        recordButton.style.color = ''; // Reset color
+        recordButton.textContent = 'REC Clip';
+        recordButton.style.color = '';
 
-        // Clear the automatic stop timer
         if (stopTimeoutId) {
             clearTimeout(stopTimeoutId);
             stopTimeoutId = null;
         }
 
         try {
-            // Send message to background script to stop
             await chrome.runtime.sendMessage({ action: "stopRecording" });
             console.log("YouTube Clip Recorder: Stop recording message sent.");
-            // Optional: Maybe disable button briefly while saving?
             recordButton.disabled = true;
-            setTimeout(() => { recordButton.disabled = false; }, 1000); // Re-enable after a short delay
-
+            setTimeout(() => { recordButton.disabled = false; }, 1000);
         } catch (error) {
             console.error("YouTube Clip Recorder: Error stopping recording.", error);
             alert(`Error stopping recording: ${error.message}`);
-            // UI is already reset, maybe just log error
         }
     }
 }
 
-// --- Initialization and Handling YouTube's Dynamic Loading ---
+function showPreviewModal({ clipId, url, filename }) {
+    discardPreviewLocally();
 
-function initialize() {
-    // Check if button already exists (maybe from navigating back/forth)
-    if (!document.getElementById('yt-clip-recorder-button')) {
-        recordButton = createRecordButton();
-        isRecording = false; // Ensure state is reset on init
-    } else {
-         recordButton = document.getElementById('yt-clip-recorder-button');
-         // Make sure state reflects reality if user navigated away while recording was pending
-         // (A more robust solution might query background script for state)
-         if (recordButton.textContent !== 'REC Clip') {
-             recordButton.textContent = 'REC Clip';
-             recordButton.style.color = '';
-             isRecording = false;
-         }
+    activePreviewClipId = clipId;
+
+    const overlay = document.createElement('div');
+    overlay.id = 'yt-clip-preview-overlay';
+    overlay.innerHTML = `
+        <div class="yt-clip-preview-modal" role="dialog" aria-label="Clip preview">
+            <button class="yt-clip-preview-close" aria-label="Close preview">✕</button>
+            <h3>Preview Clip</h3>
+            <video controls src="${url}"></video>
+            <p class="yt-clip-preview-filename">${filename}</p>
+            <div class="yt-clip-preview-actions">
+                <button class="yt-clip-btn yt-clip-save">Save</button>
+                <button class="yt-clip-btn yt-clip-save-as">Save As…</button>
+                <button class="yt-clip-btn yt-clip-discard">Discard</button>
+            </div>
+        </div>
+    `;
+
+    const onDiscard = async () => {
+        if (!activePreviewClipId) return;
+        await chrome.runtime.sendMessage({
+            action: "discardClip",
+            payload: { clipId: activePreviewClipId },
+        });
+        discardPreviewLocally();
+    };
+
+    overlay.querySelector('.yt-clip-save')?.addEventListener('click', async () => {
+        if (!activePreviewClipId) return;
+        await chrome.runtime.sendMessage({
+            action: "saveClip",
+            payload: { clipId: activePreviewClipId, saveAs: false },
+        });
+        discardPreviewLocally();
+    });
+
+    overlay.querySelector('.yt-clip-save-as')?.addEventListener('click', async () => {
+        if (!activePreviewClipId) return;
+        await chrome.runtime.sendMessage({
+            action: "saveClip",
+            payload: { clipId: activePreviewClipId, saveAs: true },
+        });
+        discardPreviewLocally();
+    });
+
+    overlay.querySelector('.yt-clip-discard')?.addEventListener('click', onDiscard);
+    overlay.querySelector('.yt-clip-preview-close')?.addEventListener('click', onDiscard);
+    overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+            onDiscard();
+        }
+    });
+
+    document.body.appendChild(overlay);
+    previewModalEl = overlay;
+}
+
+function discardPreviewLocally() {
+    if (previewModalEl) {
+        previewModalEl.remove();
+        previewModalEl = null;
+    }
+    activePreviewClipId = null;
+}
+
+async function cleanupPreviewOnUnload() {
+    if (!activePreviewClipId) return;
+    try {
+        await chrome.runtime.sendMessage({
+            action: "discardClip",
+            payload: { clipId: activePreviewClipId },
+        });
+    } catch (error) {
+        console.warn("YouTube Clip Recorder: Failed to cleanup preview clip.", error);
     }
 }
 
-// Observe for changes in the DOM, specifically targeting the player area or URL changes
-// YouTube navigation often updates the DOM without a full page load.
+chrome.runtime.onMessage.addListener((message) => {
+    if (message.action === 'clipReadyForPreview') {
+        showPreviewModal(message.payload);
+    }
+});
 
-// Simple approach: Use setInterval to check if the button needs to be added
-// This isn't the most efficient, but easier than complex MutationObservers for now
+window.addEventListener('beforeunload', cleanupPreviewOnUnload);
+
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+        cleanupPreviewOnUnload();
+    }
+});
+
+function initialize() {
+    if (!document.getElementById('yt-clip-recorder-button')) {
+        recordButton = createRecordButton();
+        isRecording = false;
+    } else {
+        recordButton = document.getElementById('yt-clip-recorder-button');
+        if (recordButton.textContent !== 'REC Clip') {
+            recordButton.textContent = 'REC Clip';
+            recordButton.style.color = '';
+            isRecording = false;
+        }
+    }
+}
+
 const checkInterval = setInterval(() => {
-    // Check if we are on a watch page and if the button's parent exists
     if (window.location.href.includes("/watch") && document.querySelector('.ytp-right-controls')) {
         initialize();
     } else {
-        // If we navigated away from a watch page, ensure recording stops if it was active
-        // (This check might be redundant if background handles tab closure/update, but good for safety)
         if (isRecording) {
-           console.log("YouTube Clip Recorder: Navigated away, attempting to stop recording if active.");
-           chrome.runtime.sendMessage({ action: "stopRecording" }).catch(e => console.log("Error sending stop on navigate away:", e));
-           isRecording = false;
-           if(recordButton) {
-               recordButton.textContent = 'REC Clip';
-               recordButton.style.color = '';
-           }
-           if(stopTimeoutId) clearTimeout(stopTimeoutId);
+            console.log("YouTube Clip Recorder: Navigated away, attempting to stop recording if active.");
+            chrome.runtime.sendMessage({ action: "stopRecording" }).catch((e) => console.log("Error sending stop on navigate away:", e));
+            isRecording = false;
+            if (recordButton) {
+                recordButton.textContent = 'REC Clip';
+                recordButton.style.color = '';
+            }
+            if (stopTimeoutId) clearTimeout(stopTimeoutId);
         }
-        // Remove button if it exists but we are not on a watch page anymore
         const existingButton = document.getElementById('yt-clip-recorder-button');
         if (existingButton) {
             existingButton.remove();
             recordButton = null;
         }
     }
-}, 1000); // Check every second
+}, 1000);
 
-// Initial attempt to add the button
 initialize();

--- a/style.css
+++ b/style.css
@@ -1,18 +1,83 @@
 #yt-clip-recorder-button {
-    /* Inherits .ytp-button styles if injection works */
-    /* Add overrides or specific styles here if needed */
-    margin-left: 8px !important; /* Ensure spacing */
+    margin-left: 8px !important;
     font-size: 0.9em !important;
     padding: 5px 8px !important;
-    line-height: normal; /* Ensure text fits */
-    /* Add a subtle border or background on hover? */
+    line-height: normal;
 }
 
-#yt-clip-recorder-button:hover {
-  /* background-color: rgba(255, 255, 255, 0.2); */
-}
-
-/* Style when recording */
 #yt-clip-recorder-button[style*="color: red"] {
     font-weight: bold;
+}
+
+#yt-clip-preview-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.7);
+}
+
+.yt-clip-preview-modal {
+    width: min(520px, 90vw);
+    background: #111;
+    color: #fff;
+    border-radius: 10px;
+    padding: 16px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+    position: relative;
+}
+
+.yt-clip-preview-modal h3 {
+    margin: 0 0 12px;
+    font-size: 18px;
+}
+
+.yt-clip-preview-modal video {
+    width: 100%;
+    border-radius: 8px;
+    background: #000;
+}
+
+.yt-clip-preview-filename {
+    margin: 10px 0;
+    font-size: 12px;
+    color: #b3b3b3;
+    word-break: break-all;
+}
+
+.yt-clip-preview-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.yt-clip-btn {
+    border: none;
+    border-radius: 6px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.yt-clip-save,
+.yt-clip-save-as {
+    background: #3ea6ff;
+    color: #000;
+}
+
+.yt-clip-discard {
+    background: #2a2a2a;
+    color: #fff;
+}
+
+.yt-clip-preview-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    border: none;
+    background: transparent;
+    color: #fff;
+    cursor: pointer;
+    font-size: 16px;
 }


### PR DESCRIPTION
### Motivation
- Improve UX by letting users preview a recorded clip before it is downloaded to disk.
- Avoid immediate downloads and potential memory leaks by managing temporary object URLs and giving users explicit save/discard control.

### Description
- Stop auto-downloading in `background.js`: create a blob URL, track pending clips in a `pendingClips` Map, and send a `clipReadyForPreview` message with metadata to the originating tab instead of calling `chrome.downloads.download` immediately.
- Add new background message handlers `saveClip` (supports optional `saveAs`) and `discardClip`, and revoke object URLs on discard, after save cleanup, and on error paths.
- Implement an in-page preview modal in `content.js` that mounts a `<video controls>` bound to the object URL and exposes `Save`, `Save As…`, and `Discard` actions wired to the background actions; the modal also dismisses on overlay/close click.
- Add lifecycle cleanup in the content script (`beforeunload` and `visibilitychange`) and styles in `style.css` for the modal to ensure temporary URLs are discarded on unload and to provide a basic preview UI.

### Testing
- Ran static checks: `node --check background.js` succeeded and `node --check content.js` succeeded.
- Manually exercised the preview layout and captured a screenshot of the preview modal to validate UI styling (artifact generated).
- Verified object URLs are revoked via the `discardClip` path and a delayed cleanup after `saveClip` to avoid leaks while downloads start.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0be2ebf08325803fb161efd2dea1)