### PR TITLE
Add 'include audio' recording toggle with MIME/extension fallback

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,9 +2,33 @@ let mediaStream = null;
 let mediaRecorder = null;
 let recordedBlobs = [];
 let captureInfo = { title: "youtube_clip", timestamp: "00:00" }; // Store title/time
+let currentMimeType = "video/webm";
+let currentFileExtension = "webm";
 
-const VIDEO_MIME_TYPE = 'video/webm;codecs=vp9'; // VP9 is generally good for web
-// const VIDEO_MIME_TYPE = 'video/mp4;codecs=h264'; // Alternative, might have less browser support for recording
+const VIDEO_MIME_CANDIDATES = [
+    { type: 'video/webm;codecs=vp9,opus', extension: 'webm' },
+    { type: 'video/webm;codecs=vp8,opus', extension: 'webm' },
+    { type: 'video/webm;codecs=vp9', extension: 'webm' },
+    { type: 'video/webm;codecs=vp8', extension: 'webm' },
+    { type: 'video/webm', extension: 'webm' },
+    { type: 'video/mp4;codecs=avc1.42E01E,mp4a.40.2', extension: 'mp4' },
+    { type: 'video/mp4', extension: 'mp4' },
+];
+
+function selectSupportedMimeType(includeAudio) {
+    const compatibleType = VIDEO_MIME_CANDIDATES.find((candidate) => {
+        if (includeAudio && !candidate.type.includes('opus') && !candidate.type.includes('mp4a') && candidate.type.includes('codecs=')) {
+            return false;
+        }
+        return MediaRecorder.isTypeSupported(candidate.type);
+    });
+
+    if (compatibleType) {
+        return compatibleType;
+    }
+
+    return { type: '', extension: 'webm' };
+}
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Use an async function here to allow 'await' and properly handle promises/sendResponse
@@ -18,6 +42,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
             console.log("Background: Received startRecording", message.payload);
             captureInfo = message.payload || captureInfo; // Store title/time
+            const includeAudio = Boolean(message.payload?.includeAudio);
 
             try {
                 // Important: Get the tab where the message came from
@@ -28,7 +53,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
                 // Start tab capture
                 mediaStream = await chrome.tabCapture.capture({
-                    audio: false, // No audio as requested
+                    audio: includeAudio,
                     video: true,
                     videoConstraints: {
                         mandatory: {
@@ -51,8 +76,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 // Clear previous blobs
                 recordedBlobs = [];
 
+                const selectedMime = selectSupportedMimeType(includeAudio);
+                currentMimeType = selectedMime.type || 'video/webm';
+                currentFileExtension = selectedMime.extension;
+
                 // Create MediaRecorder
-                 mediaRecorder = new MediaRecorder(mediaStream, { mimeType: VIDEO_MIME_TYPE });
+                const recorderOptions = selectedMime.type ? { mimeType: selectedMime.type } : undefined;
+                mediaRecorder = recorderOptions ? new MediaRecorder(mediaStream, recorderOptions) : new MediaRecorder(mediaStream);
 
                 mediaRecorder.ondataavailable = (event) => {
                     if (event.data && event.data.size > 0) {
@@ -102,12 +132,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 function handleRecordingStop() {
     console.log("Background: MediaRecorder stopped.");
     if (recordedBlobs && recordedBlobs.length > 0) {
-        const blob = new Blob(recordedBlobs, { type: VIDEO_MIME_TYPE });
+        const blob = new Blob(recordedBlobs, { type: currentMimeType });
 
         // Sanitize filename
         const safeTitle = captureInfo.title.replace(/[<>:"/\\|?*]+/g, '_').substring(0, 100); // Limit length too
         const timestamp = captureInfo.timestamp || "00:00";
-        const filename = `${safeTitle}_clip_${timestamp}.webm`; // Use .webm extension
+        const audioSuffix = captureInfo.includeAudio ? '_with-audio' : '';
+        const filename = `${safeTitle}_clip_${timestamp}${audioSuffix}.${currentFileExtension}`;
 
         const url = URL.createObjectURL(blob);
 

--- a/content.js
+++ b/content.js
@@ -1,9 +1,43 @@
 console.log("YouTube Clip Recorder: Content script loaded.");
 
 let recordButton = null;
+let audioToggle = null;
 let isRecording = false;
 let stopTimeoutId = null; // Timer to auto-stop recording
 const MAX_RECORD_DURATION_MS = 10000; // 10 seconds
+const AUDIO_PREF_KEY = 'includeTabAudio';
+
+async function getIncludeAudioPreference() {
+    const stored = await chrome.storage.local.get({ [AUDIO_PREF_KEY]: false });
+    return Boolean(stored[AUDIO_PREF_KEY]);
+}
+
+function createAudioToggle() {
+    if (document.getElementById('yt-clip-recorder-audio-toggle')) {
+        return document.getElementById('yt-clip-recorder-audio-toggle');
+    }
+
+    const label = document.createElement('label');
+    label.id = 'yt-clip-recorder-audio-toggle';
+    label.className = 'yt-clip-recorder-audio-toggle ytp-button';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = 'yt-clip-recorder-audio-checkbox';
+    checkbox.title = 'Include tab audio in recording';
+
+    const text = document.createElement('span');
+    text.textContent = 'Audio';
+
+    checkbox.addEventListener('change', async () => {
+        await chrome.storage.local.set({ [AUDIO_PREF_KEY]: checkbox.checked });
+    });
+
+    label.appendChild(checkbox);
+    label.appendChild(text);
+
+    return label;
+}
 
 function createRecordButton() {
     if (document.getElementById('yt-clip-recorder-button')) {
@@ -25,14 +59,19 @@ function createRecordButton() {
     // This selector might change with YouTube updates!
     const controlsRight = document.querySelector('.ytp-right-controls');
     if (controlsRight) {
+        const toggle = createAudioToggle();
+
         // Insert it before the settings button for visibility
         const settingsButton = controlsRight.querySelector('.ytp-settings-button');
         if (settingsButton) {
+            controlsRight.insertBefore(toggle, settingsButton);
             controlsRight.insertBefore(button, settingsButton);
         } else {
              // Fallback: append to the end of right controls
+             controlsRight.appendChild(toggle);
              controlsRight.appendChild(button);
         }
+        audioToggle = toggle;
         console.log("YouTube Clip Recorder: Button injected.");
         return button;
     } else {
@@ -66,12 +105,13 @@ async function handleRecordButtonClick() {
         const videoTitle = document.title.replace(/ - YouTube$/, ''); // Get clean title
         const currentTimeSeconds = Math.floor(videoElement.currentTime);
         const timestamp = new Date(currentTimeSeconds * 1000).toISOString().substr(14, 5); // Format as MM:SS
+        const includeAudio = Boolean(audioToggle?.querySelector('input')?.checked);
 
         try {
             // Send message to background script to start
             await chrome.runtime.sendMessage({
                 action: "startRecording",
-                payload: { title: videoTitle, timestamp: timestamp }
+                payload: { title: videoTitle, timestamp: timestamp, includeAudio }
             });
             console.log("YouTube Clip Recorder: Start recording message sent.");
 
@@ -122,7 +162,7 @@ async function handleRecordButtonClick() {
 
 // --- Initialization and Handling YouTube's Dynamic Loading ---
 
-function initialize() {
+async function initialize() {
     // Check if button already exists (maybe from navigating back/forth)
     if (!document.getElementById('yt-clip-recorder-button')) {
         recordButton = createRecordButton();
@@ -136,6 +176,16 @@ function initialize() {
              recordButton.style.color = '';
              isRecording = false;
          }
+    }
+
+    if (!audioToggle) {
+        audioToggle = document.getElementById('yt-clip-recorder-audio-toggle');
+    }
+
+    const includeAudio = await getIncludeAudioPreference();
+    const checkbox = audioToggle?.querySelector('input');
+    if (checkbox) {
+        checkbox.checked = includeAudio;
     }
 }
 
@@ -163,9 +213,14 @@ const checkInterval = setInterval(() => {
         }
         // Remove button if it exists but we are not on a watch page anymore
         const existingButton = document.getElementById('yt-clip-recorder-button');
+        const existingToggle = document.getElementById('yt-clip-recorder-audio-toggle');
         if (existingButton) {
             existingButton.remove();
             recordButton = null;
+        }
+        if (existingToggle) {
+            existingToggle.remove();
+            audioToggle = null;
         }
     }
 }, 1000); // Check every second

--- a/style.css
+++ b/style.css
@@ -8,6 +8,21 @@
     /* Add a subtle border or background on hover? */
 }
 
+#yt-clip-recorder-audio-toggle {
+    display: inline-flex !important;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+    color: white;
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+#yt-clip-recorder-audio-toggle input {
+    margin: 0;
+    cursor: pointer;
+}
+
 #yt-clip-recorder-button:hover {
   /* background-color: rgba(255, 255, 255, 0.2); */
 }


### PR DESCRIPTION
### Motivation

- Allow users to optionally include tab audio when recording clips (previously audio was hardcoded off).
- Pass the audio preference from the content script to the background service worker so `chrome.tabCapture.capture` can enable audio when requested.
- Handle MediaRecorder MIME/codec/container incompatibilities when audio is included by falling back to the first supported candidate at runtime.
- Make output filenames reflect whether audio was captured (append `_with-audio`).

### Description

- Confirmed `manifest.json` already grants required permissions (`tabCapture` and `storage`), so no manifest edits were needed.
- Updated `background.js` to read `includeAudio` from the `startRecording` payload and pass it into `chrome.tabCapture.capture({ audio: ... })`, added `VIDEO_MIME_CANDIDATES`, implemented `selectSupportedMimeType(includeAudio)`, and choose a supported `MediaRecorder` mimeType/extension at start; uses `currentMimeType`/`currentFileExtension` for the Blob/download and appends `_with-audio` to the filename when appropriate.
- Updated `content.js` to inject a small `Audio` toggle next to the record button, persist the preference in `chrome.storage.local`, load the stored default on initialization, and include `{ includeAudio }` in the `startRecording` message payload.
- Added basic styles for the new audio toggle in `style.css` so it integrates with YouTube controls.

### Testing

- Ran JavaScript syntax checks with `node --check background.js` and `node --check content.js`, both succeeded.
- Executed an automated Playwright script to load YouTube and capture a page screenshot to validate content script injection timing (succeeded and produced a screenshot artifact).
- No unit tests were added for the runtime MediaRecorder behavior because that requires a browser environment; runtime selection logic is defensive and falls back to supported types when available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0bdd8f808325a0532080203b044e)