### PR TITLE
Add configurable max recording duration via extension popup

### DIFF
--- a/content.js
+++ b/content.js
@@ -3,7 +3,32 @@ console.log("YouTube Clip Recorder: Content script loaded.");
 let recordButton = null;
 let isRecording = false;
 let stopTimeoutId = null; // Timer to auto-stop recording
-const MAX_RECORD_DURATION_MS = 10000; // 10 seconds
+
+const DEFAULT_MAX_RECORD_DURATION_MS = 10000; // 10 seconds fallback
+const MIN_RECORD_DURATION_SECONDS = 3;
+const MAX_RECORD_DURATION_SECONDS = 60;
+const STORAGE_KEY_MAX_DURATION_SECONDS = 'maxRecordDurationSeconds';
+
+function clampDurationSeconds(value) {
+    const seconds = Number.parseInt(value, 10);
+
+    if (Number.isNaN(seconds)) {
+        return DEFAULT_MAX_RECORD_DURATION_MS / 1000;
+    }
+
+    return Math.min(MAX_RECORD_DURATION_SECONDS, Math.max(MIN_RECORD_DURATION_SECONDS, seconds));
+}
+
+async function getMaxRecordDurationMs() {
+    try {
+        const settings = await chrome.storage.sync.get(STORAGE_KEY_MAX_DURATION_SECONDS);
+        const boundedSeconds = clampDurationSeconds(settings?.[STORAGE_KEY_MAX_DURATION_SECONDS]);
+        return boundedSeconds * 1000;
+    } catch (error) {
+        console.warn("YouTube Clip Recorder: Failed to load duration from storage, using default.", error);
+        return DEFAULT_MAX_RECORD_DURATION_MS;
+    }
+}
 
 function createRecordButton() {
     if (document.getElementById('yt-clip-recorder-button')) {
@@ -76,10 +101,11 @@ async function handleRecordButtonClick() {
             console.log("YouTube Clip Recorder: Start recording message sent.");
 
             // Set timeout for automatic stop
+            const maxRecordDurationMs = await getMaxRecordDurationMs();
             stopTimeoutId = setTimeout(() => {
                 console.log("YouTube Clip Recorder: Max duration reached, stopping automatically.");
                 handleRecordButtonClick(); // Call this function again to trigger the stop logic
-            }, MAX_RECORD_DURATION_MS);
+            }, maxRecordDurationMs);
 
         } catch (error) {
             console.error("YouTube Clip Recorder: Error starting recording.", error);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "YouTube Clip Recorder",
   "version": "0.1.0",
-  "description": "Record short video clips (up to 10s) from YouTube videos.",
+  "description": "Record short video clips from YouTube videos.",
   "permissions": [
     "tabCapture",  // To capture video stream
     "scripting",   // To inject content script programmatically (though we'll use static injection here)
@@ -24,9 +24,8 @@
     }
   ],
   "action": {
-    // We'll add a popup later for settings/previews. For now, it's just an icon.
-    "default_title": "YouTube Clip Recorder"
-    // "default_popup": "popup.html" // Future addition
+    "default_title": "YouTube Clip Recorder",
+    "default_popup": "popup.html"
   },
   "icons": {
     // Replace with your actual icon paths if you have them

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>YouTube Clip Recorder Settings</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 12px;
+      min-width: 220px;
+    }
+
+    label,
+    select,
+    button {
+      display: block;
+      width: 100%;
+      margin-bottom: 8px;
+    }
+
+    #status {
+      font-size: 12px;
+      min-height: 16px;
+      color: #1a7f37;
+    }
+  </style>
+</head>
+<body>
+  <label for="duration">Max recording duration</label>
+  <select id="duration">
+    <option value="3">3 seconds</option>
+    <option value="5">5 seconds</option>
+    <option value="10">10 seconds</option>
+    <option value="15">15 seconds</option>
+    <option value="20">20 seconds</option>
+    <option value="30">30 seconds</option>
+    <option value="45">45 seconds</option>
+    <option value="60">60 seconds</option>
+  </select>
+  <button id="save" type="button">Save</button>
+  <div id="status" aria-live="polite"></div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,58 @@
+const DEFAULT_MAX_RECORD_DURATION_SECONDS = 10;
+const MIN_RECORD_DURATION_SECONDS = 3;
+const MAX_RECORD_DURATION_SECONDS = 60;
+const STORAGE_KEY_MAX_DURATION_SECONDS = 'maxRecordDurationSeconds';
+
+const durationSelect = document.getElementById('duration');
+const saveButton = document.getElementById('save');
+const statusElement = document.getElementById('status');
+
+function clampDurationSeconds(value) {
+  const seconds = Number.parseInt(value, 10);
+
+  if (Number.isNaN(seconds)) {
+    return DEFAULT_MAX_RECORD_DURATION_SECONDS;
+  }
+
+  return Math.min(MAX_RECORD_DURATION_SECONDS, Math.max(MIN_RECORD_DURATION_SECONDS, seconds));
+}
+
+function setStatus(message, isError = false) {
+  statusElement.textContent = message;
+  statusElement.style.color = isError ? '#b42318' : '#1a7f37';
+}
+
+async function loadSettings() {
+  try {
+    const settings = await chrome.storage.sync.get(STORAGE_KEY_MAX_DURATION_SECONDS);
+    const seconds = clampDurationSeconds(settings?.[STORAGE_KEY_MAX_DURATION_SECONDS]);
+    durationSelect.value = String(seconds);
+    setStatus('');
+  } catch (error) {
+    console.error('Failed to load max duration setting.', error);
+    durationSelect.value = String(DEFAULT_MAX_RECORD_DURATION_SECONDS);
+    setStatus('Could not load saved setting.', true);
+  }
+}
+
+async function saveSettings() {
+  const selectedValue = durationSelect.value;
+  const seconds = clampDurationSeconds(selectedValue);
+
+  if (Number.parseInt(selectedValue, 10) !== seconds) {
+    durationSelect.value = String(seconds);
+    setStatus(`Duration must be between ${MIN_RECORD_DURATION_SECONDS}s and ${MAX_RECORD_DURATION_SECONDS}s.`, true);
+    return;
+  }
+
+  try {
+    await chrome.storage.sync.set({ [STORAGE_KEY_MAX_DURATION_SECONDS]: seconds });
+    setStatus('Saved.');
+  } catch (error) {
+    console.error('Failed to save max duration setting.', error);
+    setStatus('Could not save setting.', true);
+  }
+}
+
+saveButton.addEventListener('click', saveSettings);
+document.addEventListener('DOMContentLoaded', loadSettings);


### PR DESCRIPTION
### Motivation
- Allow users to control the maximum clip length instead of a fixed 10s timeout by loading the duration from extension storage and exposing a simple UI.
- Ensure recorded clips respect safe bounds (to prevent too-short or overly long captures) with a reasonable fallback when settings are missing.

### Description
- Replaced the hardcoded `MAX_RECORD_DURATION_MS` in `content.js` with `getMaxRecordDurationMs()` that reads `maxRecordDurationSeconds` from `chrome.storage.sync` and applies clamping via `clampDurationSeconds()`; default fallback remains 10s.
- Added a popup UI (`popup.html`) and logic (`popup.js`) providing a duration selector (3–60s) and persisting the selection to `chrome.storage.sync` with validation before saving.
- Wired the extension action to open the new popup by setting `"default_popup": "popup.html"` in `manifest.json`.
- Kept the previous recording start/stop flow intact and only changed the automatic stop timeout to use the stored duration.

### Testing
- Ran `node --check content.js` and it completed successfully.
- Ran `node --check popup.js` and it completed successfully.
- Attempted to render and screenshot `popup.html` with Playwright but the environment failed to load the local page, which did not affect the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0bde6d188325994b7e06fb85e4da)