### PR TITLE
Select supported WebM codec at runtime and surface clear error when none available

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,9 +2,32 @@ let mediaStream = null;
 let mediaRecorder = null;
 let recordedBlobs = [];
 let captureInfo = { title: "youtube_clip", timestamp: "00:00" }; // Store title/time
+let selectedVideoMimeType = null;
 
-const VIDEO_MIME_TYPE = 'video/webm;codecs=vp9'; // VP9 is generally good for web
-// const VIDEO_MIME_TYPE = 'video/mp4;codecs=h264'; // Alternative, might have less browser support for recording
+const VIDEO_MIME_CANDIDATES = [
+    'video/webm;codecs=vp9',
+    'video/webm;codecs=vp8',
+    'video/webm',
+];
+
+function selectSupportedMimeType() {
+    const supportedType = VIDEO_MIME_CANDIDATES.find((mimeType) => MediaRecorder.isTypeSupported(mimeType));
+    if (supportedType) {
+        console.log(`Background: Using recording MIME type: ${supportedType}`);
+        return supportedType;
+    }
+
+    console.error(`Background: No supported MIME types found. Candidates: ${VIDEO_MIME_CANDIDATES.join(', ')}`);
+    return null;
+}
+
+function getExtensionFromMimeType(mimeType) {
+    if (mimeType && mimeType.includes('webm')) {
+        return 'webm';
+    }
+
+    return 'webm';
+}
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Use an async function here to allow 'await' and properly handle promises/sendResponse
@@ -51,8 +74,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 // Clear previous blobs
                 recordedBlobs = [];
 
+                selectedVideoMimeType = selectSupportedMimeType();
+                if (!selectedVideoMimeType) {
+                    stopCaptureResources();
+                    sendResponse({
+                        success: false,
+                        message: "This browser/system does not support any compatible recording format (VP9/VP8/WebM). Please update your browser or try another device.",
+                    });
+                    return;
+                }
+
                 // Create MediaRecorder
-                 mediaRecorder = new MediaRecorder(mediaStream, { mimeType: VIDEO_MIME_TYPE });
+                 mediaRecorder = new MediaRecorder(mediaStream, { mimeType: selectedVideoMimeType });
 
                 mediaRecorder.ondataavailable = (event) => {
                     if (event.data && event.data.size > 0) {
@@ -102,12 +135,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 function handleRecordingStop() {
     console.log("Background: MediaRecorder stopped.");
     if (recordedBlobs && recordedBlobs.length > 0) {
-        const blob = new Blob(recordedBlobs, { type: VIDEO_MIME_TYPE });
+        const blobMimeType = selectedVideoMimeType || 'video/webm';
+        const blob = new Blob(recordedBlobs, { type: blobMimeType });
+        const extension = getExtensionFromMimeType(blobMimeType);
+        console.log(`Background: Finalizing blob with MIME type: ${blobMimeType}`);
 
         // Sanitize filename
         const safeTitle = captureInfo.title.replace(/[<>:"/\\|?*]+/g, '_').substring(0, 100); // Limit length too
         const timestamp = captureInfo.timestamp || "00:00";
-        const filename = `${safeTitle}_clip_${timestamp}.webm`; // Use .webm extension
+        const filename = `${safeTitle}_clip_${timestamp}.${extension}`;
 
         const url = URL.createObjectURL(blob);
 
@@ -147,6 +183,7 @@ function stopCaptureResources() {
     }
     mediaRecorder = null;
     mediaStream = null;
+    selectedVideoMimeType = null;
     console.log("Background: Capture resources released.");
 }
 


### PR DESCRIPTION
### Motivation
- Prevent recording failures on systems/browsers that do not support VP9 by negotiating a compatible MIME at runtime.
- Keep blob creation and saved file extension consistent with the actual codec used.
- Make codec selection visible in logs to aid debugging and provide a clear user-facing error when no recording MIME is supported.

### Description
- Add a prioritized candidate list `VIDEO_MIME_CANDIDATES` and a helper `selectSupportedMimeType()` that uses `MediaRecorder.isTypeSupported()` to pick the first supported MIME. 
- Persist the chosen MIME in `selectedVideoMimeType` and use it when constructing the `MediaRecorder` and when creating the final `Blob` and filename extension via `getExtensionFromMimeType()`.
- Surface the selected MIME in console logs and return `{ success: false, message: ... }` from `startRecording` if no candidate is supported, while cleaning up resources.
- Reset `selectedVideoMimeType` in `stopCaptureResources()` to avoid stale state after cleanup.

### Testing
- Ran syntax check with `node --check background.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0be13e248325b42af25e691818ed)