### PR TITLE
Prevent UI drift by syncing recording button with background state

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,13 +4,26 @@ let recordedBlobs = [];
 let captureInfo = { title: "youtube_clip", timestamp: "00:00" }; // Store title/time
 
 const VIDEO_MIME_TYPE = 'video/webm;codecs=vp9'; // VP9 is generally good for web
-// const VIDEO_MIME_TYPE = 'video/mp4;codecs=h264'; // Alternative, might have less browser support for recording
+const RECORDING_STARTED_EVENT = "recordingStarted";
+const RECORDING_STOPPED_EVENT = "recordingStopped";
+const RECORDING_ERROR_EVENT = "recordingError";
+
+function emitRecordingState(type, payload = {}) {
+    chrome.runtime.sendMessage({ type, payload }).catch((error) => {
+        // Ignore if there are no listeners in some extension contexts.
+        console.debug(`Background: Unable to emit ${type}.`, error?.message || error);
+    });
+}
+
+function isRecordingActive() {
+    return Boolean(mediaRecorder && mediaRecorder.state === "recording");
+}
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Use an async function here to allow 'await' and properly handle promises/sendResponse
     (async () => {
         if (message.action === "startRecording") {
-            if (mediaRecorder && mediaRecorder.state !== "inactive") {
+            if (isRecordingActive()) {
                 console.warn("Background: Recording already in progress.");
                 sendResponse({ success: false, message: "Already recording." });
                 return; // Indicate message handled (implicitly)
@@ -23,7 +36,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 // Important: Get the tab where the message came from
                 const targetTabId = sender.tab?.id;
                 if (!targetTabId) {
-                   throw new Error("Could not get sender tab ID.");
+                    throw new Error("Could not get sender tab ID.");
                 }
 
                 // Start tab capture
@@ -32,7 +45,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     video: true,
                     videoConstraints: {
                         mandatory: {
-                             // Request desired quality, browser will do its best
+                            // Request desired quality, browser will do its best
                             minWidth: 1280,
                             minHeight: 720,
                             maxWidth: 1920,
@@ -44,15 +57,27 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 console.log("Background: Tab capture started.");
 
                 // Check if stream is valid
-                 if (!mediaStream || mediaStream.getVideoTracks().length === 0) {
-                     throw new Error("Failed to get video stream from tabCapture.");
-                 }
+                if (!mediaStream || mediaStream.getVideoTracks().length === 0) {
+                    throw new Error("Failed to get video stream from tabCapture.");
+                }
+
+                mediaStream.getVideoTracks().forEach((track) => {
+                    track.onended = () => {
+                        console.warn("Background: Video track ended unexpectedly.");
+                        if (isRecordingActive()) {
+                            mediaRecorder.stop();
+                        } else {
+                            stopCaptureResources();
+                            emitRecordingState(RECORDING_STOPPED_EVENT, { reason: "streamEnded" });
+                        }
+                    };
+                });
 
                 // Clear previous blobs
                 recordedBlobs = [];
 
                 // Create MediaRecorder
-                 mediaRecorder = new MediaRecorder(mediaStream, { mimeType: VIDEO_MIME_TYPE });
+                mediaRecorder = new MediaRecorder(mediaStream, { mimeType: VIDEO_MIME_TYPE });
 
                 mediaRecorder.ondataavailable = (event) => {
                     if (event.data && event.data.size > 0) {
@@ -64,34 +89,41 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 mediaRecorder.onstop = handleRecordingStop; // Assign the stop handler
 
                 mediaRecorder.onerror = (event) => {
+                    const errorMessage = event.error?.message || "MediaRecorder error";
                     console.error("Background: MediaRecorder error:", event.error);
                     // Clean up resources on error too
                     stopCaptureResources();
+                    emitRecordingState(RECORDING_ERROR_EVENT, { message: errorMessage });
+                    emitRecordingState(RECORDING_STOPPED_EVENT, { reason: "recorderError" });
                 };
 
                 // Start recording
                 mediaRecorder.start(100); // Collect data in chunks (e.g., every 100ms)
                 console.log("Background: MediaRecorder started.");
+                emitRecordingState(RECORDING_STARTED_EVENT, { title: captureInfo.title, timestamp: captureInfo.timestamp });
                 sendResponse({ success: true }); // Signal success back to content script
 
             } catch (error) {
                 console.error("Background: Error starting tab capture or MediaRecorder:", error);
                 stopCaptureResources(); // Clean up if error occurs during setup
-                 sendResponse({ success: false, message: error.message });
+                emitRecordingState(RECORDING_ERROR_EVENT, { message: error.message });
+                emitRecordingState(RECORDING_STOPPED_EVENT, { reason: "startFailed" });
+                sendResponse({ success: false, message: error.message });
             }
 
         } else if (message.action === "stopRecording") {
-             console.log("Background: Received stopRecording message.");
-             if (mediaRecorder && mediaRecorder.state === "recording") {
-                 mediaRecorder.stop(); // This will trigger the 'onstop' event handler
-                 // stopCaptureResources() is called within handleRecordingStop after blobs are processed
-                 sendResponse({ success: true });
-             } else {
-                 console.warn("Background: Stop requested but recorder not active/found.");
-                 // Still try to clean up just in case stream exists without recorder
-                 stopCaptureResources();
-                 sendResponse({ success: false, message: "Recorder not active." });
-             }
+            console.log("Background: Received stopRecording message.");
+            if (isRecordingActive()) {
+                mediaRecorder.stop(); // This will trigger the 'onstop' event handler
+                // stopCaptureResources() is called within handleRecordingStop after blobs are processed
+                sendResponse({ success: true });
+            } else {
+                console.warn("Background: Stop requested but recorder not active/found.");
+                // Still try to clean up just in case stream exists without recorder
+                stopCaptureResources();
+                emitRecordingState(RECORDING_STOPPED_EVENT, { reason: "alreadyInactive" });
+                sendResponse({ success: false, message: "Recorder not active." });
+            }
         }
     })(); // Immediately invoke the async function
 
@@ -117,31 +149,37 @@ function handleRecordingStop() {
             filename: filename,
             // saveAs: true // Uncomment to prompt user for save location each time
         }).then(downloadId => {
-             console.log(`Background: Download started with ID: ${downloadId}`);
+            console.log(`Background: Download started with ID: ${downloadId}`);
             // Note: Can't easily revokeObjectURL here directly as download is async.
             // Browser usually handles cleanup, but for long-running extensions, management might be needed.
             // setTimeout(() => URL.revokeObjectURL(url), 60000); // Revoke after 1 min as fallback
         }).catch(error => {
             console.error("Background: Download failed:", error);
             URL.revokeObjectURL(url); // Clean up if download initiation failed
+            emitRecordingState(RECORDING_ERROR_EVENT, { message: error.message || "Download failed" });
         });
 
         // Clear blobs after processing
-         recordedBlobs = [];
+        recordedBlobs = [];
     } else {
         console.warn("Background: Recording stopped but no data blobs found.");
     }
 
     // Clean up stream/recorder resources AFTER processing blobs
     stopCaptureResources();
+    emitRecordingState(RECORDING_STOPPED_EVENT, { reason: "stopped" });
 }
 
 function stopCaptureResources() {
     if (mediaRecorder && mediaRecorder.state !== "inactive") {
         // If somehow stop wasn't called cleanly, try again.
-        try { mediaRecorder.stop(); } catch (e) { console.warn("Error trying to stop recorder during cleanup:", e); }
+        try {
+            mediaRecorder.stop();
+        } catch (e) {
+            console.warn("Error trying to stop recorder during cleanup:", e);
+        }
     }
-     if (mediaStream) {
+    if (mediaStream) {
         mediaStream.getTracks().forEach(track => track.stop());
         console.log("Background: MediaStream tracks stopped.");
     }
@@ -149,27 +187,5 @@ function stopCaptureResources() {
     mediaStream = null;
     console.log("Background: Capture resources released.");
 }
-
-// Add listeners for tab updates/removal to stop recording if the target tab changes/closes
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    // Check if the tab being updated is the one we are capturing
-    // And if the URL significantly changed (navigated away) or it's loading
-    if (mediaRecorder && mediaRecorder.state === "recording") {
-         const capturingTabId = mediaRecorder?.stream?.getVideoTracks()[0]?.getSettings()?.displaySurface?.tabId;
-         // Note: reliably getting tab ID from stream isn't straightforward, might need to store it separately when starting
-         // Let's rely on stopping via content script's interval checker for now, or handle tab removal.
-    }
-});
-
-chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
-    // Check if the closed tab is the one being recorded
-    // Requires storing targetTabId when starting capture
-    // if (tabId === storedTargetTabId && mediaRecorder && mediaRecorder.state === "recording") {
-    //    console.log(`Background: Target tab ${tabId} closed, stopping recording.`);
-    //    mediaRecorder.stop(); // Trigger stop and cleanup
-    // }
-    // Simplified: For now, assume content script handles navigation away,
-    // and if the whole browser closes, things stop anyway.
-});
 
 console.log("Background Service Worker started.");

--- a/content.js
+++ b/content.js
@@ -2,8 +2,71 @@ console.log("YouTube Clip Recorder: Content script loaded.");
 
 let recordButton = null;
 let isRecording = false;
+let isTransitioning = false;
 let stopTimeoutId = null; // Timer to auto-stop recording
+let reenableTimeoutId = null;
 const MAX_RECORD_DURATION_MS = 10000; // 10 seconds
+
+function clearTimers() {
+    if (stopTimeoutId) {
+        clearTimeout(stopTimeoutId);
+        stopTimeoutId = null;
+    }
+    if (reenableTimeoutId) {
+        clearTimeout(reenableTimeoutId);
+        reenableTimeoutId = null;
+    }
+}
+
+function setButtonState({ text, color = '', disabled = false }) {
+    if (!recordButton) return;
+    recordButton.textContent = text;
+    recordButton.style.color = color;
+    recordButton.disabled = disabled;
+}
+
+function resetUIState() {
+    isRecording = false;
+    isTransitioning = false;
+    clearTimers();
+    setButtonState({ text: 'REC Clip', color: '', disabled: false });
+}
+
+function applyRecordingState() {
+    isRecording = true;
+    isTransitioning = false;
+    setButtonState({ text: 'STOP ■', color: 'red', disabled: false });
+
+    clearTimeout(stopTimeoutId);
+    stopTimeoutId = setTimeout(() => {
+        console.log("YouTube Clip Recorder: Max duration reached, stopping automatically.");
+        requestStopRecording();
+    }, MAX_RECORD_DURATION_MS);
+}
+
+async function requestStopRecording() {
+    if (!recordButton || isTransitioning) {
+        return;
+    }
+
+    isTransitioning = true;
+    setButtonState({ text: 'Stopping...', color: '', disabled: true });
+
+    try {
+        await chrome.runtime.sendMessage({ action: "stopRecording" });
+        console.log("YouTube Clip Recorder: Stop recording message sent.");
+        // If background doesn't answer with state event for any reason, recover UI quickly.
+        reenableTimeoutId = setTimeout(() => {
+            if (!isRecording) {
+                resetUIState();
+            }
+        }, 1200);
+    } catch (error) {
+        console.error("YouTube Clip Recorder: Error stopping recording.", error);
+        alert(`Error stopping recording: ${error.message}`);
+        resetUIState();
+    }
+}
 
 function createRecordButton() {
     if (document.getElementById('yt-clip-recorder-button')) {
@@ -30,25 +93,19 @@ function createRecordButton() {
         if (settingsButton) {
             controlsRight.insertBefore(button, settingsButton);
         } else {
-             // Fallback: append to the end of right controls
-             controlsRight.appendChild(button);
+            // Fallback: append to the end of right controls
+            controlsRight.appendChild(button);
         }
         console.log("YouTube Clip Recorder: Button injected.");
         return button;
-    } else {
-        console.warn("YouTube Clip Recorder: Could not find YouTube controls container.");
-        // Fallback: Append to body (less ideal)
-        // button.style.position = 'fixed';
-        // button.style.bottom = '20px';
-        // button.style.right = '20px';
-        // button.style.zIndex = '9999';
-        // document.body.appendChild(button);
-        return null; // Indicate failure to inject properly
     }
+
+    console.warn("YouTube Clip Recorder: Could not find YouTube controls container.");
+    return null; // Indicate failure to inject properly
 }
 
 async function handleRecordButtonClick() {
-    if (!recordButton) return; // Safety check
+    if (!recordButton || isTransitioning) return; // Safety check
 
     const videoElement = document.querySelector('video.html5-main-video');
     if (!videoElement) {
@@ -59,66 +116,56 @@ async function handleRecordButtonClick() {
 
     if (!isRecording) {
         // --- Start Recording ---
-        isRecording = true;
-        recordButton.textContent = 'STOP ■'; // Indicate recording
-        recordButton.style.color = 'red'; // Visual feedback
+        isTransitioning = true;
+        setButtonState({ text: 'Starting...', color: '', disabled: true });
 
         const videoTitle = document.title.replace(/ - YouTube$/, ''); // Get clean title
         const currentTimeSeconds = Math.floor(videoElement.currentTime);
         const timestamp = new Date(currentTimeSeconds * 1000).toISOString().substr(14, 5); // Format as MM:SS
 
         try {
-            // Send message to background script to start
-            await chrome.runtime.sendMessage({
+            const response = await chrome.runtime.sendMessage({
                 action: "startRecording",
                 payload: { title: videoTitle, timestamp: timestamp }
             });
-            console.log("YouTube Clip Recorder: Start recording message sent.");
 
-            // Set timeout for automatic stop
-            stopTimeoutId = setTimeout(() => {
-                console.log("YouTube Clip Recorder: Max duration reached, stopping automatically.");
-                handleRecordButtonClick(); // Call this function again to trigger the stop logic
-            }, MAX_RECORD_DURATION_MS);
+            if (!response?.success) {
+                throw new Error(response?.message || "Failed to start recording.");
+            }
+
+            console.log("YouTube Clip Recorder: Start recording message sent.");
+            // Guard: only show STOP UI when the background confirms active recording.
+            // If the event message is dropped, fallback to a local state update.
+            applyRecordingState();
 
         } catch (error) {
             console.error("YouTube Clip Recorder: Error starting recording.", error);
             alert(`Error starting recording: ${error.message}`);
-            // Reset UI if start failed
-            isRecording = false;
-            recordButton.textContent = 'REC Clip';
-            recordButton.style.color = ''; // Reset color
-            clearTimeout(stopTimeoutId);
-            stopTimeoutId = null;
+            resetUIState();
         }
 
     } else {
         // --- Stop Recording ---
-        isRecording = false;
-        recordButton.textContent = 'REC Clip'; // Reset text immediately
-        recordButton.style.color = ''; // Reset color
-
-        // Clear the automatic stop timer
-        if (stopTimeoutId) {
-            clearTimeout(stopTimeoutId);
-            stopTimeoutId = null;
-        }
-
-        try {
-            // Send message to background script to stop
-            await chrome.runtime.sendMessage({ action: "stopRecording" });
-            console.log("YouTube Clip Recorder: Stop recording message sent.");
-            // Optional: Maybe disable button briefly while saving?
-            recordButton.disabled = true;
-            setTimeout(() => { recordButton.disabled = false; }, 1000); // Re-enable after a short delay
-
-        } catch (error) {
-            console.error("YouTube Clip Recorder: Error stopping recording.", error);
-            alert(`Error stopping recording: ${error.message}`);
-            // UI is already reset, maybe just log error
-        }
+        await requestStopRecording();
     }
 }
+
+chrome.runtime.onMessage.addListener((message) => {
+    if (!message?.type) return;
+
+    if (message.type === 'recordingStarted') {
+        applyRecordingState();
+    }
+
+    if (message.type === 'recordingStopped') {
+        resetUIState();
+    }
+
+    if (message.type === 'recordingError') {
+        console.error('YouTube Clip Recorder: Background recording error.', message.payload?.message || message.payload);
+        resetUIState();
+    }
+});
 
 // --- Initialization and Handling YouTube's Dynamic Loading ---
 
@@ -126,16 +173,10 @@ function initialize() {
     // Check if button already exists (maybe from navigating back/forth)
     if (!document.getElementById('yt-clip-recorder-button')) {
         recordButton = createRecordButton();
-        isRecording = false; // Ensure state is reset on init
+        resetUIState();
     } else {
-         recordButton = document.getElementById('yt-clip-recorder-button');
-         // Make sure state reflects reality if user navigated away while recording was pending
-         // (A more robust solution might query background script for state)
-         if (recordButton.textContent !== 'REC Clip') {
-             recordButton.textContent = 'REC Clip';
-             recordButton.style.color = '';
-             isRecording = false;
-         }
+        recordButton = document.getElementById('yt-clip-recorder-button');
+        resetUIState();
     }
 }
 
@@ -150,17 +191,12 @@ const checkInterval = setInterval(() => {
         initialize();
     } else {
         // If we navigated away from a watch page, ensure recording stops if it was active
-        // (This check might be redundant if background handles tab closure/update, but good for safety)
-        if (isRecording) {
-           console.log("YouTube Clip Recorder: Navigated away, attempting to stop recording if active.");
-           chrome.runtime.sendMessage({ action: "stopRecording" }).catch(e => console.log("Error sending stop on navigate away:", e));
-           isRecording = false;
-           if(recordButton) {
-               recordButton.textContent = 'REC Clip';
-               recordButton.style.color = '';
-           }
-           if(stopTimeoutId) clearTimeout(stopTimeoutId);
+        if (isRecording || isTransitioning) {
+            console.log("YouTube Clip Recorder: Navigated away, attempting to stop recording if active.");
+            chrome.runtime.sendMessage({ action: "stopRecording" }).catch(e => console.log("Error sending stop on navigate away:", e));
+            resetUIState();
         }
+
         // Remove button if it exists but we are not on a watch page anymore
         const existingButton = document.getElementById('yt-clip-recorder-button');
         if (existingButton) {


### PR DESCRIPTION
### Motivation
- Prevent the extension UI from showing a stale `STOP` state when recording stops unexpectedly due to tab changes, permission denial, stream end, or recorder errors.
- Ensure the content script always reflects the true background recorder state so users are never left with a disabled or confusing button state.

### Description
- Emit runtime events from `background.js` (`recordingStarted`, `recordingStopped`, `recordingError`) using a shared `emitRecordingState` helper so state transitions are broadcast to content pages.
- Add `track.onended` handling and emit stop/error events on start failures, recorder errors, download failures, and inactive-stop requests to guarantee the UI can recover from all stop/error paths.
- Refactor `content.js` to centralize UI changes into `applyRecordingState` and `resetUIState`, add timer cleanup via `clearTimers`, and add `setButtonState` for consistent updates.
- Add a transition guard (`isTransitioning`) and `requestStopRecording` flow so the button only shows `STOP` after background confirmation and to prevent duplicate clicks during in-flight start/stop operations.

### Testing
- Ran syntax checks with `node --check background.js` and `node --check content.js`, and both checks passed successfully.
- No browser integration tests were run because the changes rely on Chrome extension runtime messaging and tab capture behavior which must be validated in a running browser environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0be1dd608325bd30148820837c37)