### PR TITLE
Fix manifest parsing and surface recording start/stop failures

### DIFF
--- a/content.js
+++ b/content.js
@@ -69,10 +69,13 @@ async function handleRecordButtonClick() {
 
         try {
             // Send message to background script to start
-            await chrome.runtime.sendMessage({
+            const response = await chrome.runtime.sendMessage({
                 action: "startRecording",
                 payload: { title: videoTitle, timestamp: timestamp }
             });
+            if (!response?.success) {
+                throw new Error(response?.message || 'Failed to start recording.');
+            }
             console.log("YouTube Clip Recorder: Start recording message sent.");
 
             // Set timeout for automatic stop
@@ -106,7 +109,10 @@ async function handleRecordButtonClick() {
 
         try {
             // Send message to background script to stop
-            await chrome.runtime.sendMessage({ action: "stopRecording" });
+            const response = await chrome.runtime.sendMessage({ action: "stopRecording" });
+            if (!response?.success) {
+                throw new Error(response?.message || 'Failed to stop recording.');
+            }
             console.log("YouTube Clip Recorder: Stop recording message sent.");
             // Optional: Maybe disable button briefly while saving?
             recordButton.disabled = true;

--- a/manifest.json
+++ b/manifest.json
@@ -4,34 +4,26 @@
   "version": "0.1.0",
   "description": "Record short video clips (up to 10s) from YouTube videos.",
   "permissions": [
-    "tabCapture",  // To capture video stream
-    "scripting",   // To inject content script programmatically (though we'll use static injection here)
-    "downloads",   // To save the recorded clip
-    "storage"      // For saving settings later (like auto-download toggle)
+    "tabCapture",
+    "scripting",
+    "downloads",
+    "storage"
   ],
   "host_permissions": [
-    "*://*.youtube.com/*" // Allows the extension to run on YouTube
+    "*://*.youtube.com/*"
   ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
-      "matches": ["*://*.youtube.com/watch*"], // Run only on video watch pages
+      "matches": ["*://*.youtube.com/watch*"],
       "js": ["content.js"],
       "css": ["style.css"],
-      "run_at": "document_idle" // Run after the page is mostly loaded
+      "run_at": "document_idle"
     }
   ],
   "action": {
-    // We'll add a popup later for settings/previews. For now, it's just an icon.
     "default_title": "YouTube Clip Recorder"
-    // "default_popup": "popup.html" // Future addition
-  },
-  "icons": {
-    // Replace with your actual icon paths if you have them
-    // "16": "icons/icon16.png",
-    // "48": "icons/icon48.png",
-    // "128": "icons/icon128.png"
   }
 }


### PR DESCRIPTION
### Motivation
- The extension manifest contained JavaScript-style comments which make `manifest.json` invalid JSON and can prevent Chrome from loading the extension.
- The content script assumed background start/stop calls always succeed, causing the UI to show recording when the background actually failed.
- Users experienced silent failures with no feedback when recording start/stop failed, so explicit error propagation was needed. 

### Description
- Removed inline comments and placeholder blocks from `manifest.json` to produce valid JSON so the extension can load. 
- Cleaned up the `action` block in `manifest.json` to avoid commented-out entries that broke strict parsing. 
- Updated `content.js` to capture the result of `chrome.runtime.sendMessage` for both `startRecording` and `stopRecording`. 
- Added explicit throws when the background response is `{ success: false }` so the UI is reset and the user receives an error alert. 

### Testing
- Verified `manifest.json` parses with `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8')); console.log('manifest ok')"` which succeeded. 
- Type/parse-checked `content.js` with `node --check content.js` which succeeded. 
- Type/parse-checked `background.js` with `node --check background.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0a00e80c8325b81dcd20458ed318)