### PR TITLE
Fix DOM observer reinjection condition

### DIFF
--- a/content.js
+++ b/content.js
@@ -419,7 +419,7 @@ function startDomObservation() {
     domObserver = new MutationObserver(() => {
         if (!isWatchPageUrl()) return;
 
-        if (!document.getElementById('yt-clip-recorder-button') || document.querySelector('.ytp-right-controls')) {
+        if (!document.getElementById('yt-clip-recorder-button') && document.querySelector('.ytp-right-controls')) {
             debouncedInitialize();
         }
     });


### PR DESCRIPTION
### Motivation
- Prevent unnecessary reinjection churn from the content-script's MutationObserver by ensuring the reinjection guard only triggers when the recorder button is missing and YouTube right-controls are present.

### Description
- Update `content.js` to change the MutationObserver condition from `||` to `&&` so `debouncedInitialize()` runs only when `!document.getElementById('yt-clip-recorder-button')` **and** `document.querySelector('.ytp-right-controls')` are true.

### Testing
- Ran `node --check content.js`, `node --check background.js`, and `node --check popup.js`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d15d65b388325bc50b4f53f63a320)